### PR TITLE
Fix makefile - add /usr/local/include to PG_CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJS := $(patsubst %.cpp,%.o,$(cpp_files))
 
 # C flags
 PG_CPPFLAGS := -fPIC -std=c++14
-PG_CPPFLAGS += -Isrc/ -I/usr/include
+PG_CPPFLAGS += -Isrc/ -I/usr/include -I/usr/local/include
 PG_CPPFLAGS += -Wall -Wextra
 ifeq ($(CONFIG),debug)
 	PG_CPPFLAGS += -g -Og


### PR DESCRIPTION
Installing libphonenumber using `homebrew` puts the header files into
`/usr/local/include/` instead of `/usr/include/`